### PR TITLE
fix: errors

### DIFF
--- a/src/MorphoToken.sol
+++ b/src/MorphoToken.sol
@@ -27,14 +27,14 @@ contract MorphoToken is ERC20VotesUpgradeable, ERC20PermitUpgradeable, Ownable2S
 
     /* ERRORS */
 
-    /// @notice Reverts if the address is the zero address.
-    error ZeroAddress();
+    /// @notice Thrown when a zero address is passed as input.
+    string internal constant ZERO_ADDRESS = "zero address";
 
     /* PUBLIC */
 
     function initialize(address dao, address wrapper) public initializer {
-        require(dao != address(0), ZeroAddress());
-        require(wrapper != address(0), ZeroAddress());
+        require(dao != address(0), ZERO_ADDRESS);
+        require(wrapper != address(0), ZERO_ADDRESS);
 
         ERC20VotesUpgradeable.__ERC20Votes_init();
         ERC20Upgradeable.__ERC20_init(NAME, SYMBOL);

--- a/src/Wrapper.sol
+++ b/src/Wrapper.sol
@@ -20,17 +20,17 @@ contract Wrapper {
 
     /* ERRORS */
 
-    /// @notice Reverts if the address is the zero address.
-    error ZeroAddress();
+    /// @notice Thrown when a zero address is passed as input.
+    string internal constant ZERO_ADDRESS = "zero address";
 
-    /// @notice Reverts if the address is the contract address.
-    error SelfAddress();
+    /// @notice Thrown when the contract address is passed as input.
+    string internal constant SELF_ADDRESS = "self address";
 
     /* CONSTRUCTOR */
 
     /// @dev morphoToken address can be precomputed using create2.
     constructor(address morphoToken) {
-        require(morphoToken != address(0), ZeroAddress());
+        require(morphoToken != address(0), ZERO_ADDRESS);
 
         NEW_MORPHO = morphoToken;
     }
@@ -39,8 +39,8 @@ contract Wrapper {
 
     /// @dev Compliant to `ERC20Wrapper` contract from OZ for convenience.
     function depositFor(address account, uint256 amount) public returns (bool) {
-        require(account != address(0), ZeroAddress());
-        require(account != address(this), SelfAddress());
+        require(account != address(0), ZERO_ADDRESS);
+        require(account != address(this), SELF_ADDRESS);
 
         IERC20(LEGACY_MORPHO).transferFrom(msg.sender, address(this), amount);
         IERC20(NEW_MORPHO).transfer(account, amount);


### PR DESCRIPTION
`Require` can only take strings as inputs, not custom errors

The other solution (if we want to keep custom errors) is to replace `require` by `if` + `revert`