### PR TITLE
Inline `_transferVotingUnits & remove `_totalVotingPower`

### DIFF
--- a/src/ERC20DelegatesUpgradeable.sol
+++ b/src/ERC20DelegatesUpgradeable.sol
@@ -44,7 +44,6 @@ abstract contract ERC20DelegatesUpgradeable is
     struct ERC20DelegatesStorage {
         mapping(address account => address) _delegatee;
         mapping(address delegatee => uint256) _votingPower;
-        uint256 _totalVotingPower;
     }
 
     /* PUBLIC */
@@ -92,19 +91,6 @@ abstract contract ERC20DelegatesUpgradeable is
         _moveDelegateVotes(oldDelegate, delegatee, _getVotingUnits(account));
     }
 
-    /// @dev Transfers, mints, or burns voting units. To register a mint, `from` should be zero. To register a burn, `to`
-    /// should be zero. Total supply of voting units will be adjusted with mints and burns.
-    function _transferVotingUnits(address from, address to, uint256 amount) internal {
-        ERC20DelegatesStorage storage $ = _getERC20DelegatesStorage();
-        if (from == address(0)) {
-            $._totalVotingPower += amount;
-        }
-        if (to == address(0)) {
-            $._totalVotingPower -= amount;
-        }
-        _moveDelegateVotes(delegates(from), delegates(to), amount);
-    }
-
     /// @dev Must return the voting units held by an account.
     function _getVotingUnits(address account) internal view returns (uint256) {
         return balanceOf(account);
@@ -115,7 +101,7 @@ abstract contract ERC20DelegatesUpgradeable is
     function _update(address from, address to, uint256 value) internal virtual override {
         super._update(from, to, value);
         // No check of supply cap here like in OZ implementation as MORPHO has a 1B total supply cap.
-        _transferVotingUnits(from, to, value);
+        _moveDelegateVotes(delegates(from), delegates(to), value);
     }
 
     /* PRIVATE */


### PR DESCRIPTION
The purpose of this PR is to inline `_transferVotingUnits`. 

Following [this message](https://morpholabs.slack.com/archives/C02N7CZ088N/p1729253531465229?thread_ts=1729234494.917469&cid=C02N7CZ088N) it also removes the `_totalVotingPower` storage field.