### PR TITLE
Remove redundant `wrapper != 0` check

### DIFF
--- a/src/MorphoToken.sol
+++ b/src/MorphoToken.sol
@@ -36,7 +36,6 @@ contract MorphoToken is ERC20DelegatesUpgradeable, ERC20PermitUpgradeable, Ownab
     /// @param wrapper The wrapper contract address to migrate legacy MORPHO tokens to the new one.
     function initialize(address dao, address wrapper) public initializer {
         require(dao != address(0), ZeroAddress());
-        require(wrapper != address(0), ZeroAddress());
 
         ERC20Upgradeable.__ERC20_init(NAME, SYMBOL);
         Ownable2StepUpgradeable.__Ownable2Step_init();


### PR DESCRIPTION
OZ already implements checking that mint recipients are not `address(0)`.