### PR TITLE
Test ERC20 delegate storage location value

### DIFF
--- a/test/MorphoToken.t.sol
+++ b/test/MorphoToken.t.sol
@@ -201,4 +201,10 @@ contract MorphoTokenTest is BaseTest {
         assertEq(newMorpho.getVotes(delegatee1), initialAmount - transferredAmount);
         assertEq(newMorpho.getVotes(delegatee2), transferredAmount);
     }
+
+    function testERC20DelegatesStorageLocation() public pure {
+        bytes32 expected =
+            keccak256(abi.encode(uint256(keccak256("morpho.storage.ERC20Delegates")) - 1)) & ~bytes32(uint256(0xff));
+        assertEq(expected, 0x1dc92b2c6e971ab6e08dfd7dcec0e9496d223ced663ba2a06543451548549500);
+    }
 }


### PR DESCRIPTION
Add a test to make sure the [comment](https://github.com/morpho-org/morpho-token-upgradeable/blob/08b98901444141f23a1e0090f88850149048ef91/src/ERC20DelegatesUpgradeable.sol#L37) above the definition of `ERC20DelegatesStorageLocation` is correct.