### PR TITLE
feat: rename getVotes

### DIFF
--- a/src/ERC20DelegatesUpgradeable.sol
+++ b/src/ERC20DelegatesUpgradeable.sol
@@ -48,8 +48,8 @@ abstract contract ERC20DelegatesUpgradeable is
 
     /* PUBLIC */
 
-    /// @dev Returns the current amount of votes that `account` has.
-    function getVotes(address account) public view returns (uint256) {
+    /// @dev Returns the current amount of delegated votes that `account` has.
+    function getDelegatedVotes(address account) public view returns (uint256) {
         ERC20DelegatesStorage storage $ = _getERC20DelegatesStorage();
         return $._votingPower[account];
     }

--- a/src/interfaces/IDelegates.sol
+++ b/src/interfaces/IDelegates.sol
@@ -16,7 +16,7 @@ interface IDelegates {
     event DelegateVotesChanged(address indexed delegate, uint256 previousVotes, uint256 newVotes);
 
     // @dev Returns the current amount of votes that `account` has.
-    function getVotes(address account) external view returns (uint256);
+    function getDelegatedVotes(address account) external view returns (uint256);
 
     // @dev Returns the delegate that `account` has chosen.
     function delegates(address account) external view returns (address);

--- a/test/MorphoToken.t.sol
+++ b/test/MorphoToken.t.sol
@@ -48,7 +48,7 @@ contract MorphoTokenTest is BaseTest {
         newMorpho.delegate(delegator);
 
         assertEq(newMorpho.delegates(delegator), delegator);
-        assertEq(newMorpho.getVotes(delegator), amount);
+        assertEq(newMorpho.getDelegatedVotes(delegator), amount);
     }
 
     function testDelegate(address delegator, address delegatee, uint256 amount) public {
@@ -64,8 +64,8 @@ contract MorphoTokenTest is BaseTest {
         newMorpho.delegate(delegatee);
 
         assertEq(newMorpho.delegates(delegator), delegatee);
-        assertEq(newMorpho.getVotes(delegator), 0);
-        assertEq(newMorpho.getVotes(delegatee), amount);
+        assertEq(newMorpho.getDelegatedVotes(delegator), 0);
+        assertEq(newMorpho.getDelegatedVotes(delegatee), amount);
     }
 
     function testDelegateBySigExpired(SigUtils.Delegation memory delegation, uint256 privateKey, uint256 expiry)
@@ -139,8 +139,8 @@ contract MorphoTokenTest is BaseTest {
         newMorpho.delegateBySig(delegation.delegatee, delegation.nonce, delegation.expiry, sig.v, sig.r, sig.s);
 
         assertEq(newMorpho.delegates(delegator), delegation.delegatee);
-        assertEq(newMorpho.getVotes(delegator), 0);
-        assertEq(newMorpho.getVotes(delegation.delegatee), amount);
+        assertEq(newMorpho.getDelegatedVotes(delegator), 0);
+        assertEq(newMorpho.getDelegatedVotes(delegation.delegatee), amount);
         assertEq(newMorpho.nonces(delegator), 1);
     }
 
@@ -168,7 +168,7 @@ contract MorphoTokenTest is BaseTest {
         vm.prank(delegator2);
         newMorpho.delegate(delegatee);
 
-        assertEq(newMorpho.getVotes(delegatee), amount1 + amount2);
+        assertEq(newMorpho.getDelegatedVotes(delegatee), amount1 + amount2);
     }
 
     function testTransferVotingPower(
@@ -198,7 +198,7 @@ contract MorphoTokenTest is BaseTest {
         newMorpho.transfer(delegator2, transferredAmount);
         vm.stopPrank();
 
-        assertEq(newMorpho.getVotes(delegatee1), initialAmount - transferredAmount);
-        assertEq(newMorpho.getVotes(delegatee2), transferredAmount);
+        assertEq(newMorpho.getDelegatedVotes(delegatee1), initialAmount - transferredAmount);
+        assertEq(newMorpho.getDelegatedVotes(delegatee2), transferredAmount);
     }
 }


### PR DESCRIPTION
The idea is that whereas the self delegation is required to vote or not will be decided at the voting contract level (by the slot used and verified in the contract), but not in the token contract.

Furthermore, while the `getVotes` function is central in the ERC20Votes, as it is the function called by the voting contract to get an account's voting power, here it is purely informative.

So I'll just call it `getDelegatedVotes` to expose a getter of the delegated voting power slot.