### PR TITLE
Remove "unit" naming

### DIFF
--- a/src/ERC20DelegatesUpgradeable.sol
+++ b/src/ERC20DelegatesUpgradeable.sol
@@ -94,12 +94,7 @@ abstract contract ERC20DelegatesUpgradeable is Initializable, ERC20Upgradeable, 
         $._delegatee[account] = delegatee;
 
         emit DelegateChanged(account, oldDelegate, delegatee);
-        _moveDelegateVotes(oldDelegate, delegatee, _getVotingUnits(account));
-    }
-
-    /// @dev Must return the voting units held by an account.
-    function _getVotingUnits(address account) internal view returns (uint256) {
-        return balanceOf(account);
+        _moveDelegateVotes(oldDelegate, delegatee, balanceOf(account));
     }
 
     /// @dev Moves voting power when tokens are transferred.


### PR DESCRIPTION
As it's not necessary (the rest is removed in #35)