### PR TITLE
Rename DelegationTokenStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Additionally, it ships a wrapper contract to simplify the migration of assets fr
 
 ## Upgradability
 
-The Morpho token complies with the EIP-1967 to support upgradeability.
+The Morpho token complies with the [EIP-1967](https://eips.ethereum.org/EIPS/eip-1967) to support upgradeability.
 
 ## Delegation
 
@@ -21,7 +21,6 @@ With the functions `depositFor` and `withdrawTo`, this contract ensures complian
 The `Wrapper` contract will hold the migrated legacy tokens.
 
 ### Migration Flow
-
 
 During contract intialization, 1 billion tokens will be minted for the `Wrapper` contract, which will initially hold the entire supply.
 Any legacy token holder will then be able to migrate their tokens provided that the migration amount is the approved for the wrapper.

--- a/test/MorphoTokenTest.sol
+++ b/test/MorphoTokenTest.sol
@@ -229,7 +229,7 @@ contract MorphoTokenEthereumTest is BaseTest {
         assertEq(newMorpho.delegatedVotingPower(delegatee2), transferredAmount);
     }
 
-    function testERC20DelegatesStorageLocation() public pure {
+    function testDelegationTokenStorageLocation() public pure {
         bytes32 expected =
             keccak256(abi.encode(uint256(keccak256("morpho.storage.ERC20Delegates")) - 1)) & ~bytes32(uint256(0xff));
         assertEq(expected, 0x1dc92b2c6e971ab6e08dfd7dcec0e9496d223ced663ba2a06543451548549500);


### PR DESCRIPTION
For consistency, we rename the `DelegationToken` storage.