### PR TITLE
Internal tests

### DIFF
--- a/test/DelegationTokenInternalTest.sol
+++ b/test/DelegationTokenInternalTest.sol
@@ -7,7 +7,7 @@ import {DelegationToken} from "../src/DelegationToken.sol";
 contract DelegationTokenInternalTest is Test, DelegationToken {
     uint256 internal constant MAX_TEST_AMOUNT = 1e28;
 
-    function getInitializableStorage() internal pure returns (InitializableStorage storage $) {
+    function _getInitializableStorage() internal pure returns (InitializableStorage storage $) {
         assembly {
             $.slot := 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00
         }
@@ -19,7 +19,7 @@ contract DelegationTokenInternalTest is Test, DelegationToken {
     }
 
     function testDisabledInitializers() public view {
-        InitializableStorage storage $ = getInitializableStorage();
+        InitializableStorage storage $ = _getInitializableStorage();
         assertEq($._initialized, type(uint64).max, "Initializers not disabled");
     }
 

--- a/test/DelegationTokenInternalTest.sol
+++ b/test/DelegationTokenInternalTest.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test, console} from "../lib/forge-std/src/Test.sol";
+import {DelegationToken} from "../src/DelegationToken.sol";
+
+contract DelegationTokenInternalTest is Test, DelegationToken {
+    function testDelegationTokenStorageLocation() public pure {
+        bytes32 expectedSlot =
+            keccak256(abi.encode(uint256(keccak256("DelegationToken")) - 1)) & ~bytes32(uint256(0xff));
+        bytes32 usedSlot = DelegationTokenStorageLocation;
+        assertEq(expectedSlot, usedSlot, "Wrong slot used");
+    }
+}

--- a/test/DelegationTokenInternalTest.sol
+++ b/test/DelegationTokenInternalTest.sol
@@ -5,10 +5,22 @@ import {Test, console} from "../lib/forge-std/src/Test.sol";
 import {DelegationToken} from "../src/DelegationToken.sol";
 
 contract DelegationTokenInternalTest is Test, DelegationToken {
+    uint256 internal constant MAX_TEST_AMOUNT = 1e28;
+
     function getInitializableStorage() internal pure returns (InitializableStorage storage $) {
         assembly {
             $.slot := 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00
         }
+    }
+
+    function _delegatedVotingPower(address account) internal view returns (uint256) {
+        DelegationTokenStorage storage $ = _getDelegationTokenStorage();
+        return $._delegatedVotingPower[account];
+    }
+
+    function testDisabledInitializers() public view {
+        InitializableStorage storage $ = getInitializableStorage();
+        assertEq($._initialized, type(uint64).max, "Initializers not disabled");
     }
 
     function testDelegationTokenStorageLocation() public pure {
@@ -18,8 +30,54 @@ contract DelegationTokenInternalTest is Test, DelegationToken {
         assertEq(expectedSlot, usedSlot, "Wrong slot used");
     }
 
-    function testDisabledInitializers() public view {
-        InitializableStorage storage $ = getInitializableStorage();
-        assertEq($._initialized, type(uint64).max, "Initializers not disabled");
+    function testMoveDelegateVotesDifferentAccounts(
+        address from,
+        address to,
+        uint256 initialVoteFrom,
+        uint256 initialVoteTo,
+        uint256 amount
+    ) public {
+        // Setup
+        DelegationTokenStorage storage $ = _getDelegationTokenStorage();
+        initialVoteFrom = bound(initialVoteFrom, 0, MAX_TEST_AMOUNT);
+        $._delegatedVotingPower[from] = initialVoteFrom;
+        initialVoteTo = bound(initialVoteTo, 0, MAX_TEST_AMOUNT);
+        $._delegatedVotingPower[to] = initialVoteTo;
+
+        assertEq(_delegatedVotingPower(from), initialVoteFrom);
+        assertEq(_delegatedVotingPower(to), initialVoteTo);
+
+        // Test
+        amount = bound(amount, 0, initialVoteFrom);
+        _moveDelegateVotes(from, to, amount);
+
+        uint256 expectedVoteFrom = from == address(0) ? initialVoteFrom : initialVoteFrom - amount;
+        uint256 expectedVoteTo = to == address(0) ? initialVoteTo : initialVoteTo + amount;
+
+        assertEq(_delegatedVotingPower(from), expectedVoteFrom, "move delegate from");
+        assertEq(_delegatedVotingPower(to), expectedVoteTo, "move delegate to");
+    }
+
+    function testMoveDelegateVotesSameAccounts(address account, uint256 initialVote, uint256 amount) public {
+        // Setup
+        DelegationTokenStorage storage $ = _getDelegationTokenStorage();
+        $._delegatedVotingPower[account] = initialVote;
+        assertEq(_delegatedVotingPower(account), initialVote);
+
+        // Test
+        _moveDelegateVotes(account, account, amount);
+
+        assertEq(_delegatedVotingPower(account), initialVote, "unchanged delegate account");
+    }
+
+    function testDelegate(address delegator, address oldDelegatee, address newDelegatee) public {
+        // Setup
+        DelegationTokenStorage storage $ = _getDelegationTokenStorage();
+        $._delegatee[delegator] = oldDelegatee;
+        assertEq(delegatee(delegator), oldDelegatee);
+
+        // Test
+        _delegate(delegator, newDelegatee);
+        assertEq(delegatee(delegator), newDelegatee);
     }
 }

--- a/test/DelegationTokenInternalTest.sol
+++ b/test/DelegationTokenInternalTest.sol
@@ -5,10 +5,21 @@ import {Test, console} from "../lib/forge-std/src/Test.sol";
 import {DelegationToken} from "../src/DelegationToken.sol";
 
 contract DelegationTokenInternalTest is Test, DelegationToken {
+    function getInitializableStorage() internal pure returns (InitializableStorage storage $) {
+        assembly {
+            $.slot := 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00
+        }
+    }
+
     function testDelegationTokenStorageLocation() public pure {
         bytes32 expectedSlot =
             keccak256(abi.encode(uint256(keccak256("DelegationToken")) - 1)) & ~bytes32(uint256(0xff));
         bytes32 usedSlot = DelegationTokenStorageLocation;
         assertEq(expectedSlot, usedSlot, "Wrong slot used");
+    }
+
+    function testDisabledInitializers() public view {
+        InitializableStorage storage $ = getInitializableStorage();
+        assertEq($._initialized, type(uint64).max, "Initializers not disabled");
     }
 }

--- a/test/DelegationTokenInternalTest.sol
+++ b/test/DelegationTokenInternalTest.sol
@@ -7,7 +7,7 @@ import {DelegationToken} from "../src/DelegationToken.sol";
 contract DelegationTokenInternalTest is Test, DelegationToken {
     uint256 internal constant MAX_TEST_AMOUNT = 1e28;
 
-    function _getInitializableStorage() internal pure returns (InitializableStorage storage $) {
+    function __getInitializableStorage() internal pure returns (InitializableStorage storage $) {
         assembly {
             $.slot := 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00
         }
@@ -19,7 +19,7 @@ contract DelegationTokenInternalTest is Test, DelegationToken {
     }
 
     function testDisabledInitializers() public view {
-        InitializableStorage storage $ = _getInitializableStorage();
+        InitializableStorage storage $ = __getInitializableStorage();
         assertEq($._initialized, type(uint64).max, "Initializers not disabled");
     }
 

--- a/test/MorphoTokenEthereumTest.sol
+++ b/test/MorphoTokenEthereumTest.sol
@@ -229,12 +229,6 @@ contract MorphoTokenEthereumTest is BaseTest {
         assertEq(newMorpho.delegatedVotingPower(delegatee2), transferredAmount);
     }
 
-    function testDelegationTokenStorageLocation() public pure {
-        bytes32 expected =
-            keccak256(abi.encode(uint256(keccak256("morpho.storage.ERC20Delegates")) - 1)) & ~bytes32(uint256(0xff));
-        assertEq(expected, 0x1dc92b2c6e971ab6e08dfd7dcec0e9496d223ced663ba2a06543451548549500);
-    }
-
     function testMint(address to, uint256 amount) public {
         vm.assume(to != address(0));
         amount = bound(amount, MIN_TEST_AMOUNT, MAX_TEST_AMOUNT);

--- a/test/MorphoTokenOptimismTest.sol
+++ b/test/MorphoTokenOptimismTest.sol
@@ -112,10 +112,4 @@ contract MorphoTokenOptimismTest is Test {
         assertEq(morphoOptimism.totalSupply(), amountMinted - amountBurned, "totalSupply");
         assertEq(morphoOptimism.balanceOf(from), amountMinted - amountBurned, "balanceOf(account)");
     }
-
-    function testOptimismMintableERC20StorageLocation() public pure {
-        bytes32 expected = keccak256(abi.encode(uint256(keccak256("morpho.storage.OptimismMintableERC20")) - 1))
-            & ~bytes32(uint256(0xff));
-        assertEq(expected, 0x6fd4c0a11d0843c68c809f0a5f29b102d54bc08a251c384d9ad17600bfa05d00);
-    }
 }


### PR DESCRIPTION
This PR introduces tests for the internal functions of `DelegationToken`, including the constructor.

It also fixes:
- #47 