### PR TITLE
`abstracts` folder

### DIFF
--- a/src/MorphoTokenEthereum.sol
+++ b/src/MorphoTokenEthereum.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.27;
 
-import {DelegationToken} from "./DelegationToken.sol";
+import {DelegationToken} from "./abstracts/DelegationToken.sol";
 
 /// @title MorphoTokenEthereum
 /// @author Morpho Association

--- a/src/MorphoTokenOptimism.sol
+++ b/src/MorphoTokenOptimism.sol
@@ -5,7 +5,7 @@ import {IOptimismMintableERC20} from "./interfaces/IOptimismMintableERC20.sol";
 import {IERC165} from
     "../lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
 
-import {DelegationToken} from "./DelegationToken.sol";
+import {DelegationToken} from "./abstracts/DelegationToken.sol";
 
 /// @title MorphoTokenOptimism
 /// @author Morpho Association

--- a/src/abstracts/DelegationToken.sol
+++ b/src/abstracts/DelegationToken.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.27;
 
-import {IDelegation} from "./interfaces/IDelegation.sol";
+import {IDelegation} from "../interfaces/IDelegation.sol";
 
 import {ERC20PermitUpgradeable} from
-    "../lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+    "../../lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 import {ECDSA} from
-    "../lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+    "../../lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 import {Ownable2StepUpgradeable} from
-    "../lib/openzeppelin-contracts-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
-import {UUPSUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+    "../../lib/openzeppelin-contracts-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {UUPSUpgradeable} from "../../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 /// @title DelegationToken
 /// @author Morpho Association

--- a/test/DelegationTokenInternalTest.sol
+++ b/test/DelegationTokenInternalTest.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test, console} from "../lib/forge-std/src/Test.sol";
-import {DelegationToken} from "../src/DelegationToken.sol";
+import {DelegationToken} from "../src/abstracts/DelegationToken.sol";
 
 contract DelegationTokenInternalTest is Test, DelegationToken {
     uint256 internal constant MAX_TEST_AMOUNT = 1e28;

--- a/test/MorphoTokenEthereumTest.sol
+++ b/test/MorphoTokenEthereumTest.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import {BaseTest} from "./helpers/BaseTest.sol";
 import {SigUtils} from "./helpers/SigUtils.sol";
 import {MorphoTokenEthereum} from "../src/MorphoTokenEthereum.sol";
-import {DelegationToken} from "../src/DelegationToken.sol";
+import {DelegationToken} from "../src/abstracts/DelegationToken.sol";
 import {IERC20Errors} from
     "../lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/interfaces/draft-IERC6093.sol";
 import {OwnableUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";


### PR DESCRIPTION
Fixes #72 

The purpose is to have only the deployed contract at src's root